### PR TITLE
Apply baked transform to use-tags too.

### DIFF
--- a/applytransform.py
+++ b/applytransform.py
@@ -87,7 +87,8 @@ class ApplyTransform(inkex.Effect):
 
         elif node.tag in [inkex.addNS('rect', 'svg'),
                           inkex.addNS('text', 'svg'),
-                          inkex.addNS('image', 'svg')]:
+                          inkex.addNS('image', 'svg'),
+                          inkex.addNS('use', 'svg')]:
             node.set('transform', formatTransform(transf))
 
         for child in node.getchildren():


### PR DESCRIPTION
Just added the "use"-tag to the list of nodes that just get a copy of the baked transform. Otherwise Symbols (how references via use-tags are called in Inkscape) would loose their location and jump to the page origin.
Symbols can be created and used directly via the Inscape GUI, so they should be handled correctly.